### PR TITLE
fix(package): add transformer.js to package file

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "comments"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "transformer.js"
   ],
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
When running the latest version of remark-remove-comments, I get the following error:

```text
Cannot find module './transformer.js' from 'node_modules/remark-remove-comments/index.js'

    Require stack:
      node_modules/remark-remove-comments/index.js
      packages/remark-ignore/test/unit-index.test.ts

      1 | import { remark } from 'remark';
      2 | import remarkReferenceLinks from 'remark-reference-links';
    > 3 | import remarkRemoveComments from 'remark-remove-comments';
        | ^
      4 |
      5 | import remarkIgnore, { ignoreStart, ignoreEnd } from 'pkgverse/remark-ignore/src/index';
      6 | import defaultIgnoreStart from 'pkgverse/remark-ignore/src/start';

      at Resolver._throwModNotFoundError (node_modules/jest-resolve/build/resolver.js:425:11)
      at Object.<anonymous> (node_modules/remark-remove-comments/index.js:1:1)
      at Object.<anonymous> (packages/remark-ignore/test/unit-index.test.ts:3:1)
```

Seems the `transform.js` file is missing from the `files` array in your `package.json`. This PR adds it :)

Closes #5 