### PR TITLE
add declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './transformer';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "license": "MIT",
   "dependencies": {
     "html-comment-regex": "^1.1.2",
-    "unist-util-visit": "^4.1.2"
+    "unist-util-visit": "^4.1.2",
+    "vfile": "^6.0.3"
   },
   "devDependencies": {
     "remark": "^15.0.1"

--- a/transformer.d.ts
+++ b/transformer.d.ts
@@ -1,0 +1,10 @@
+import { Root } from 'mdast';
+import { VFile } from 'vfile';
+
+/**
+ * Removes every HTML node that matches this [regex](https://github.com/stevemao/html-comment-regex)
+ *
+ * @returns
+ *   Transform.
+ */
+export default function transformer(): (tree: Root, file?: VFile) => undefined;


### PR DESCRIPTION
I was having trouble using this plugin in a TypeScript project with the error: 
“TS7016: Could not find a declaration file for module `remark-remove-comments`.

The declaration file did not exist, so I created it.

The declaration file of [`remark-breaks`](https://github.com/remarkjs/remark-breaks) is a reference.