### PR TITLE
Update package.json: include the declaration flies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   ],
   "files": [
     "index.js",
-    "transformer.js"
+    "index.d.ts",
+    "transformer.js",
+    "transformer.d.ts"
   ],
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
I forgot to include the type declaration files in package.json, so I could not install these files from npm.
I'm sorry.

So I added them to package.json.
This time there should be no problem.